### PR TITLE
bugfix::title of issue goes outside card

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                 <div class="issue-grid">
                     <div
                         v-for="result in results"
-                        class="border border-gray-200 p-4 shadow-sm"
+                        class="border border-gray-200 p-4 shadow-sm break-words"
                         :title="result.title"
                     >
                         <a target="_blank" :href="result.html_url">


### PR DESCRIPTION
This pull request is in regards to [#214](https://github.com/hacktoberfest-finder/hacktoberfest-finder/issues/214) title of the issue going outside the card.

changes made:
- to index.html w.r.t card

 