### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@
 ## 2021
 
 - [Manoj Krishna](https://github.com/manojkrishnak)
+- [Aman Dutt](https://github.com/adgamerx)
 
 
 ## 2020

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git clone git@github.com:YOUR-GITHUB-USERNAME/hacktoberfest-finder.git
 
 ## Contributing
 
-Before contributing any pull requests to this pull request, please read the [`CONTRIBUTING.md`](CONTRIBUTING) document. It details the project's code of conduct and the process of submitting pull requests.
+Before contributing any pull requests to this pull request, please read the [`CONTRIBUTING.md`](./CONTRIBUTING.md) document. It details the project's code of conduct and the process of submitting pull requests.
 
 Please don't try and submit pull requests for every open issue - leave some for others!
 


### PR DESCRIPTION
## Description

The link to CONTRIBUTING.md in README.md was broken. That cause it to redirect users to the GitHub error 404 page.

## Related Issues

Fixed issue #221 

## Checklist

* [x] I've added my name into `CONTRIBUTING.md`
* [x] I have read over the [Contributors Guide]() for this project
