### PR TITLE
fix: seperate query params by whitespace

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,7 +5,7 @@
 - [Manoj Krishna](https://github.com/manojkrishnak)
 - [Aman Dutt](https://github.com/adgamerx)
 - [Faran Shaikh](https://github.com/faran4engg)
-
+- [Benjamin Knorr](https://github.com/knorrke)
 
 ## 2020
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -30,9 +30,9 @@ new Vue({
                 search(
                   type: REPOSITORY
                   query: """
-                  topic:hacktoberfest
-                  created:>=2020-01-01
-                  language:${this.selectedLanguage}
+                  topic:hacktoberfest 
+                  created:>=2020-01-01 
+                  language:${this.selectedLanguage} 
                   """
                   first: 30
                   after:${this.cursor?`"${this.cursor}"`:null}


### PR DESCRIPTION
## Description
Fix query params by seperate them with whitespace.
Before (notice that none of these actually use Rust):
![grafik](https://user-images.githubusercontent.com/11499926/135917594-aaec7dcd-74ad-459d-b0cb-597b86452e6b.png)
After:
![grafik](https://user-images.githubusercontent.com/11499926/135917471-217cee29-f6ca-49aa-bf65-4fb81b6db3be.png)

## Related Issues
Fixes #227 

## Checklist

* [X] I've added my name into `CONTRIBUTING.md`
* [X] I have read over the [Contributors Guide](https://github.com/hacktoberfest-finder/hacktoberfest-finder/blob/ca4f199eea8661cad6b7b02ddaa9f70320ccb163/CONTRIBUTING.md) for this project
